### PR TITLE
Add configurable virtual spawner drops

### DIFF
--- a/src/fr/maxlego08/spawner/SpawnerListener.java
+++ b/src/fr/maxlego08/spawner/SpawnerListener.java
@@ -406,6 +406,15 @@ public class SpawnerListener extends ListenerAdapter {
         storage.getSpawnerByDeadEntity(entity).ifPresent(spawner -> {
 
             spawner.getDeadEntities().remove(entity);
+
+            if (spawner.getType() == SpawnerType.VIRTUAL) {
+                List<ItemStack> customDrops = this.plugin.getManager().generateCustomVirtualDrops(spawner.getEntityType(), event.getEntity().getKiller());
+                if (!customDrops.isEmpty()) {
+                    event.getDrops().clear();
+                    event.getDrops().addAll(customDrops);
+                }
+            }
+
             List<ItemStack> itemStacks = new ArrayList<>(event.getDrops());
 
             /*if (spawner.isEnableAutoSell()) {

--- a/src/fr/maxlego08/spawner/SpawnerManager.java
+++ b/src/fr/maxlego08/spawner/SpawnerManager.java
@@ -22,6 +22,7 @@ import fr.maxlego08.spawner.buttons.virtual.InfoButton;
 import fr.maxlego08.spawner.buttons.virtual.ItemsButton;
 import fr.maxlego08.spawner.buttons.virtual.RemoveButton;
 import fr.maxlego08.spawner.buttons.virtual.ShopButton;
+import fr.maxlego08.spawner.drop.CustomVirtualDrop;
 import fr.maxlego08.spawner.loader.ToggleDropLoader;
 import fr.maxlego08.spawner.materials.SpawnerItemLoader;
 import fr.maxlego08.spawner.materials.SpawnerOptionItemLoader;
@@ -47,6 +48,7 @@ import org.bukkit.persistence.PersistentDataType;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +66,7 @@ public class SpawnerManager extends YamlUtils implements Savable, Runnable {
     private Map<EntityType, String> entitiesMaterials = new HashMap<>();
     private List<Material> blacklistMaterials = new ArrayList<>();
     private SpawnerOption defaultSpawnerOption;
+    private final Map<EntityType, List<CustomVirtualDrop>> customVirtualDrops = new HashMap<>();
 
     public SpawnerManager(SpawnerPlugin plugin) {
         super(plugin);
@@ -208,7 +211,23 @@ public class SpawnerManager extends YamlUtils implements Savable, Runnable {
         this.entitiesMaterials = loadEntityMaterials();
         this.blacklistMaterials = loadBlacklist();
         this.defaultSpawnerOption = loadDefaultSpawnerOption();
+        this.customVirtualDrops.clear();
+        this.customVirtualDrops.putAll(loadCustomVirtualDrops(configuration, file));
         this.loadInventories();
+    }
+
+    public List<ItemStack> generateCustomVirtualDrops(EntityType entityType, Player player) {
+        List<CustomVirtualDrop> drops = this.customVirtualDrops.get(entityType);
+        if (drops == null || drops.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<ItemStack> itemStacks = new ArrayList<>();
+        for (CustomVirtualDrop drop : drops) {
+            drop.generate(player, entityType).ifPresent(itemStacks::add);
+        }
+
+        return itemStacks;
     }
 
     public void loadButtons() {
@@ -370,5 +389,60 @@ public class SpawnerManager extends YamlUtils implements Savable, Runnable {
 
         openVirtualSpawner(player, spawner, 1);
         return isSuccess;
+    }
+
+    private Map<EntityType, List<CustomVirtualDrop>> loadCustomVirtualDrops(YamlConfiguration configuration, File file) {
+        Map<EntityType, List<CustomVirtualDrop>> drops = new HashMap<>();
+        InventoryManager inventoryManager = this.plugin.getInventoryManager();
+
+        List<?> customDrops = configuration.getList("custom-virtual-drops");
+        if (customDrops == null) {
+            return drops;
+        }
+
+        for (int index = 0; index < customDrops.size(); index++) {
+            String basePath = "custom-virtual-drops." + index + ".";
+            String entityName = configuration.getString(basePath + "entity");
+            if (entityName == null) {
+                continue;
+            }
+
+            EntityType entityType;
+            try {
+                entityType = EntityType.valueOf(entityName.toUpperCase());
+            } catch (IllegalArgumentException exception) {
+                warn("Warning: Entity type " + entityName + " not found for custom virtual drops and will be ignored.");
+                continue;
+            }
+
+            List<?> dropList = configuration.getList(basePath + "drops");
+            if (dropList == null) {
+                continue;
+            }
+
+            List<CustomVirtualDrop> customVirtualDrops = new ArrayList<>();
+            for (int dropIndex = 0; dropIndex < dropList.size(); dropIndex++) {
+                String dropPath = basePath + "drops." + dropIndex + ".";
+                double chance = configuration.getDouble(dropPath + "chance", 100.0);
+                int min = configuration.getInt(dropPath + "min", 1);
+                int max = configuration.getInt(dropPath + "max", min);
+
+                try {
+                    MenuItemStack menuItemStack = inventoryManager.loadItemStack(configuration, dropPath + "item.", file);
+                    if (menuItemStack == null) {
+                        continue;
+                    }
+                    customVirtualDrops.add(new CustomVirtualDrop(menuItemStack, chance, min, max));
+                } catch (Exception exception) {
+                    exception.printStackTrace();
+                }
+            }
+
+            if (!customVirtualDrops.isEmpty()) {
+                drops.put(entityType, customVirtualDrops);
+            }
+        }
+
+        return drops;
     }
 }

--- a/src/fr/maxlego08/spawner/drop/CustomVirtualDrop.java
+++ b/src/fr/maxlego08/spawner/drop/CustomVirtualDrop.java
@@ -1,0 +1,98 @@
+package fr.maxlego08.spawner.drop;
+
+import fr.maxlego08.menu.api.MenuItemStack;
+import fr.maxlego08.menu.api.utils.Placeholders;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Represents a custom drop configuration for a virtual spawner entity.
+ */
+public class CustomVirtualDrop {
+
+    private final MenuItemStack menuItemStack;
+    private final double chance;
+    private final int min;
+    private final int max;
+
+    public CustomVirtualDrop(MenuItemStack menuItemStack, double chance, int min, int max) {
+        this.menuItemStack = menuItemStack;
+        this.chance = chance;
+        this.min = min;
+        this.max = max;
+    }
+
+    /**
+     * Generates an {@link ItemStack} based on the drop configuration.
+     *
+     * @param player     The player used for placeholder parsing. Can be {@code null}.
+     * @param entityType The entity type associated with the drop.
+     * @return An {@link Optional} containing the generated {@link ItemStack} when the drop succeeds.
+     */
+    public Optional<ItemStack> generate(Player player, EntityType entityType) {
+
+        double finalChance = Math.max(0.0, this.chance);
+        if (finalChance <= 0.0) {
+            return Optional.empty();
+        }
+
+        if (ThreadLocalRandom.current().nextDouble(100.0) >= finalChance) {
+            return Optional.empty();
+        }
+
+        Placeholders placeholders = new Placeholders();
+        if (entityType != null) {
+            placeholders.register("entity", entityType.name());
+            placeholders.register("translation", entityType.translationKey());
+        }
+
+        ItemStack itemStack = this.menuItemStack.build(player, false, placeholders);
+        if (itemStack == null) {
+            return Optional.empty();
+        }
+
+        int minAmount = Math.min(this.min, this.max);
+        int maxAmount = Math.max(this.min, this.max);
+
+        if (maxAmount <= 0) {
+            maxAmount = 1;
+        }
+        if (minAmount <= 0) {
+            minAmount = 1;
+        }
+
+        int amount = minAmount;
+        if (maxAmount > minAmount) {
+            amount = ThreadLocalRandom.current().nextInt(maxAmount - minAmount + 1) + minAmount;
+        }
+
+        amount = Math.min(amount, itemStack.getMaxStackSize());
+        if (amount <= 0) {
+            amount = 1;
+        }
+
+        itemStack.setAmount(amount);
+        return Optional.of(itemStack);
+    }
+
+    public MenuItemStack getMenuItemStack() {
+        return menuItemStack;
+    }
+
+    public double getChance() {
+        return chance;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public int getMax() {
+        return max;
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -339,6 +339,18 @@ virtual:
     maxSpawn: 2 # Maximum spawn entity
     remaining: 1000000 # Remaining entities
 
+# Define custom drops for virtual spawners.
+# Each entry allows configuring a list of drops for a specific entity type.
+# The chance is expressed as a percentage between 0 and 100.
+custom-virtual-drops:
+  - entity: MAGMA_CUBE
+    drops:
+      - chance: 100
+        min: 1
+        max: 3
+        item:
+          material: MAGMA_CREAM
+
 # Silk spawners
 silkSpawner:
 


### PR DESCRIPTION
## Summary
- add a reusable `CustomVirtualDrop` wrapper that builds loot with zMenu menu item stacks
- extend the spawner manager to load custom virtual drop definitions from the new config section
- use the generated loot during virtual spawner entity deaths and document the configuration example

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3bc21dc88321b97075fa2765c3e1