### PR TITLE
Give virtual spawner XP directly to players

### DIFF
--- a/src/fr/maxlego08/spawner/SpawnerListener.java
+++ b/src/fr/maxlego08/spawner/SpawnerListener.java
@@ -414,6 +414,17 @@ public class SpawnerListener extends ListenerAdapter {
                     event.getDrops().clear();
                     event.getDrops().addAll(customDrops);
                 }
+
+                if (Config.givePlayerExperience) {
+                    Player killer = event.getEntity().getKiller();
+                    if (killer != null) {
+                        int droppedExp = event.getDroppedExp();
+                        if (droppedExp > 0) {
+                            event.setDroppedExp(0);
+                            killer.giveExp(droppedExp);
+                        }
+                    }
+                }
             }
 
             List<ItemStack> itemStacks = new ArrayList<>(event.getDrops());

--- a/src/fr/maxlego08/spawner/save/Config.java
+++ b/src/fr/maxlego08/spawner/save/Config.java
@@ -35,6 +35,7 @@ public class Config {
     public static List<Material> blacklistMaterials = new ArrayList<>();
     public static SpawnerType naturelSpawnerInto = SpawnerType.CLASSIC;
     public static boolean breakUpVirtualSpawner;
+    public static boolean givePlayerExperience;
 
     /**
      * static Singleton instance.
@@ -93,6 +94,7 @@ public class Config {
         }
 
         breakUpVirtualSpawner = configuration.getBoolean("breakUpVirtualSpawner", true);
+        givePlayerExperience = configuration.getBoolean("give-player-experience", false);
         dropNaturalSpawnerOnExplose = configuration.getBoolean("dropNaturalSpawnerOnExplose", true);
         disableNaturalSpawnerExplosion = configuration.getBoolean("disableNaturalSpawnerExplosion", true);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -373,4 +373,7 @@ silkSpawner:
 # Break blocks or entity of a virtual will spawn
 breakUpVirtualSpawner: true
 
+# Give experience directly to the player when killing mobs from a virtual spawner.
+give-player-experience: false
+
 deposit-reason: "Sale of x%amount% %item% for %price% (Spawner)"


### PR DESCRIPTION
## Summary
- add a configuration toggle to send experience directly to players when killing virtual spawner mobs
- grant experience to the killer immediately instead of spawning orbs when the option is enabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa41d63694832185ef6a8f030c66eb