### PR TITLE
Prevent virtual spawner overlap conflicts

### DIFF
--- a/src/fr/maxlego08/spawner/SpawnerListener.java
+++ b/src/fr/maxlego08/spawner/SpawnerListener.java
@@ -53,6 +53,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,6 +71,14 @@ public class SpawnerListener extends ListenerAdapter {
     private boolean checkBlockPlaceVirtualSpawner(BlockPlaceEvent event, Block block) {
         Optional<Spawner> optional = this.plugin.getStorage().getSpawner(block.getLocation(), SpawnerType.VIRTUAL);
         if (optional.isPresent()) {
+            event.setCancelled(true);
+            return true;
+        }
+
+        for (Entity entity : block.getWorld().getNearbyEntities(block.getLocation().clone().add(0.5, 1, 0.5), 0.5, 1.5, 0.5)) {
+            if (!(entity instanceof LivingEntity livingEntity)) continue;
+            if (!livingEntity.getPersistentDataContainer().has(this.plugin.getSpawnerKey(), PersistentDataType.STRING)) continue;
+            if (this.plugin.getStorage().getSpawnerByEntity(livingEntity).isEmpty()) continue;
             event.setCancelled(true);
             return true;
         }

--- a/src/fr/maxlego08/spawner/ZSpawner.java
+++ b/src/fr/maxlego08/spawner/ZSpawner.java
@@ -266,9 +266,11 @@ public class ZSpawner extends ZUtils implements Spawner {
 
         World world = location.getWorld();
         world.getNearbyEntities(location, 0.5, 0.5, 0.5).forEach(entity -> {
-            if (entity.getType() == this.entityType && entity.getPersistentDataContainer().has(this.plugin.getSpawnerKey())) {
-                entity.remove();
-            }
+            if (entity.getType() != this.entityType) return;
+            if (!entity.getPersistentDataContainer().has(this.plugin.getSpawnerKey(), PersistentDataType.STRING)) return;
+            String spawnerId = entity.getPersistentDataContainer().get(this.plugin.getSpawnerKey(), PersistentDataType.STRING);
+            if (spawnerId == null || !spawnerId.equals(this.uniqueId.toString())) return;
+            entity.remove();
         });
 
         Class<? extends Entity> entityClass = this.entityType.getEntityClass();


### PR DESCRIPTION
## Summary
- block placement of virtual spawners when another tracked virtual mob is already occupying the spot
- ensure virtual spawners only clear their own display entity when respawning

## Testing
- `mvn -q -DskipTests package` *(fails: blocked from downloading maven-resources-plugin 3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68fa4e555034832196d0ec3cc1465fe6